### PR TITLE
Add hourly weather data processing

### DIFF
--- a/tado_optimiser/config.yaml
+++ b/tado_optimiser/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Tado Optimiser
-version: 1.0.31
+version: 1.0.33
 slug: tado_optimiser
 description: Tado Optimiser
 url: https://github.com/charlie-chester/tado_optimiser

--- a/tado_optimiser/rootfs/main.py
+++ b/tado_optimiser/rootfs/main.py
@@ -33,6 +33,7 @@ weather = WeatherAPI(open_weather_api_key=OPEN_WEATHER_API, latitude=LATITUDE, l
 def main():
     weather.get_weather_data()
     weather.sample_update()
+    weather.hourly_entities()
 
 main()
 

--- a/tado_optimiser/rootfs/weather_api.py
+++ b/tado_optimiser/rootfs/weather_api.py
@@ -51,3 +51,61 @@ class WeatherAPI:
         }
 
         home_assistant.update_entity(sensor, payload)
+
+    def hourly_entities(self):
+        hourly_data = self.weather_data["hourly"]
+        for hour in range(0, 12):
+            wind_gust = hourly_data[hour].get("wind_gust", "No Data")
+            if wind_gust == "No Data":
+                logging.info(msg=f"No Wind Gust data found for {convert_time(hourly_data[hour]['dt'])} using default message")
+
+            rain = hourly_data[hour].get("rain", "No Data")
+            if rain == "No Data":
+                logging.info(msg=f"No Rain data found for {convert_time(hourly_data[hour]['dt'])} using default message")
+
+            snow = hourly_data[hour].get("snow", "No Data")
+            if snow == "No Data":
+                logging.info(msg=f"No Snow data found for {convert_time(hourly_data[hour]['dt'])} using default message")
+
+            sensor = f"sensor.tado_open_weather_hour_{hour}"
+            try:
+                payload = {
+                    "state": hourly_data[hour]["temp"],
+                    "attributes": {
+                        "unit_of_measurement": "°C",
+                        "friendly_name": convert_time(hourly_data[hour]["dt"]),
+                        "icon": "mdi:thermometer",
+                        "Feels like": hourly_data[hour]["feels_like"],
+                        "Pressure": hourly_data[hour]["pressure"],
+                        "Humidity": hourly_data[hour]["humidity"],
+                        "Dew point": hourly_data[hour]["dew_point"],
+                        "UVI": hourly_data[hour]["uvi"],
+                        "Clouds": hourly_data[hour]["clouds"],
+                        "Visibility": hourly_data[hour]["visibility"],
+                        "Wind speed": hourly_data[hour]["wind_speed"],
+                        "Wind gust": wind_gust,
+                        "Wind degrees": hourly_data[hour]["wind_deg"],
+                        "POP": hourly_data[hour]["pop"],
+                        "Rain": rain,
+                        "Snow": snow,
+                        "Weather - ID": hourly_data[hour]["weather"][0]["id"],
+                        "Weather - Main": hourly_data[hour]["weather"][0]["main"],
+                        "Weather - Description": hourly_data[hour]["weather"][0]["description"]
+                    }
+                }
+
+            except KeyError as e:
+                missing_key = str(e).strip("'")
+                logging.info(msg=f"KeyError: Missing key '{missing_key}' in hourly data for "
+                         f"{convert_time(hourly_data[hour]['dt'])}")
+                payload = {
+                    "state": hourly_data[hour]["temp"],
+                    "attributes": {
+                        "unit_of_measurement": "°C",
+                        "friendly_name": convert_time(hourly_data[hour]["dt"]),
+                    }
+                }
+
+            home_assistant.update_entity(sensor, payload)
+
+        logging.info(msg="Hourly entities created / updated")


### PR DESCRIPTION
Introduce `hourly_entities` method to process and log hourly weather data. The method updates entities with various weather attributes and handles missing data by logging informational messages. Also, bump version from 1.0.31 to 1.0.33.